### PR TITLE
FIX: 쪽지 API 수정 (#7)

### DIFF
--- a/src/main/java/com/iiie/server/controller/NoteController.java
+++ b/src/main/java/com/iiie/server/controller/NoteController.java
@@ -30,8 +30,8 @@ public class NoteController {
     
     @GetMapping("/latest")
     @Operation(summary = "최근 쪽지 조회", description = "가장 최근에 작성된 쪽지 3개를 조회합니다.")
-    public SuccessResponse<List<NoteDTO.NoteResponse>> getLatestNotes() {
-        List<NoteDTO.NoteResponse> notes = noteService.getLatestNotes();
+    public SuccessResponse<List<NoteDTO.NoteResponse>> getLatestNotes(@RequestBody NoteDTO.InquiryRequest inquiryRequest) {
+        List<NoteDTO.NoteResponse> notes = noteService.getLatestNotes(inquiryRequest);
         return new SuccessResponse<>("최근 쪽지 조회 완료", notes);
     }
 

--- a/src/main/java/com/iiie/server/controller/NoteController.java
+++ b/src/main/java/com/iiie/server/controller/NoteController.java
@@ -1,17 +1,16 @@
 package com.iiie.server.controller;
-import com.iiie.server.domain.Note;
-import com.iiie.server.service.NoteService;
+
 import com.iiie.server.dto.NoteDTO;
+import com.iiie.server.service.NoteService;
 import com.iiie.server.utils.SuccessResponse;
-import org.springframework.web.bind.annotation.RequestBody;
 import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import java.util.List;
 
 @RestController
 @RequestMapping("/notes")
@@ -27,7 +26,7 @@ public class NoteController {
         List<NoteDTO.NoteResponse> messages = noteService.inquiryNotes(inquiryRequest);
         return new SuccessResponse<>("쪽지 목록 조회 완료", messages);
     }
-    
+
     @PostMapping("/latest")
     @Operation(summary = "최근 쪽지 조회", description = "가장 최근에 작성된 쪽지 3개를 조회합니다.")
     public SuccessResponse<List<NoteDTO.NoteResponse>> getLatestNotes(@RequestBody NoteDTO.InquiryRequest inquiryRequest) {

--- a/src/main/java/com/iiie/server/controller/NoteController.java
+++ b/src/main/java/com/iiie/server/controller/NoteController.java
@@ -28,7 +28,7 @@ public class NoteController {
         return new SuccessResponse<>("쪽지 목록 조회 완료", messages);
     }
     
-    @GetMapping("/latest")
+    @PostMapping("/latest")
     @Operation(summary = "최근 쪽지 조회", description = "가장 최근에 작성된 쪽지 3개를 조회합니다.")
     public SuccessResponse<List<NoteDTO.NoteResponse>> getLatestNotes(@RequestBody NoteDTO.InquiryRequest inquiryRequest) {
         List<NoteDTO.NoteResponse> notes = noteService.getLatestNotes(inquiryRequest);

--- a/src/main/java/com/iiie/server/domain/Note.java
+++ b/src/main/java/com/iiie/server/domain/Note.java
@@ -27,10 +27,10 @@ public class Note {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "id")
+  @Column(name = "note_id")
   private Long id;
 
-  @Column(nullable=false)
+  @Column(nullable = false)
   private String createdBy;
 
   @Column(nullable = false)
@@ -52,5 +52,4 @@ public class Note {
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "guardian_id", nullable = false)
   private Guardian guardian;
-
 }

--- a/src/main/java/com/iiie/server/domain/Note.java
+++ b/src/main/java/com/iiie/server/domain/Note.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import lombok.AccessLevel;
@@ -27,14 +27,14 @@ public class Note {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "note_id")
+  @Column(name = "id")
   private Long id;
 
   @Column(nullable=false)
   private String createdBy;
 
   @Column(nullable = false)
-  private LocalDate createdAt;
+  private LocalDateTime createdAt;
 
   @Column(columnDefinition = "TEXT", nullable = false)
   private String noteContent;
@@ -42,8 +42,7 @@ public class Note {
   // ==시간관련==//
   @PrePersist
   private void prePersist() {
-    ZonedDateTime nowInKorea = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-    this.createdAt = nowInKorea.toLocalDate();
+    this.createdAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
   }
   // ===연관관계===//
   @ManyToOne(fetch = FetchType.EAGER)

--- a/src/main/java/com/iiie/server/dto/NoteDTO.java
+++ b/src/main/java/com/iiie/server/dto/NoteDTO.java
@@ -1,11 +1,11 @@
 package com.iiie.server.dto;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 public class NoteDTO {
     private Long id;
     private String createdBy;
-    private LocalDate createdAt;
+    private LocalDateTime createdAt;
     private String noteContent;
 
     @Getter
@@ -28,7 +28,7 @@ public class NoteDTO {
     public static class NoteResponse {
         private Long id;
         private String createdBy;
-        private LocalDate createdAt;
+        private LocalDateTime createdAt;
         private String noteContent;
     }
 

--- a/src/main/java/com/iiie/server/dto/NoteDTO.java
+++ b/src/main/java/com/iiie/server/dto/NoteDTO.java
@@ -2,6 +2,7 @@ package com.iiie.server.dto;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
+
 public class NoteDTO {
     private Long id;
     private String createdBy;
@@ -12,14 +13,14 @@ public class NoteDTO {
     @Setter
     public static class InquiryRequest {
         private Long guardianId;
-        private Long careGiverId;
+        private Long caregiverId;
     }
 
     @Getter
     @Setter
     public static class AddRequest {
         private Long guardianId;
-        private Long careGiverId;
+        private Long caregiverId;
         private String noteContent;
     }
 

--- a/src/main/java/com/iiie/server/repository/NoteRepository.java
+++ b/src/main/java/com/iiie/server/repository/NoteRepository.java
@@ -11,6 +11,9 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     // 보호자 ID로 쪽지 조회
     List<Note> findAllByGuardianId(Long guardianId);
 
-    // 가장 최근에 작성한 쪽지 3개 조회
-    List<Note> findTop3ByOrderByIdDesc();
+    // 간병인 ID로 쪽지 조회 (최신 3개)
+    List<Note> findTop3ByCaregiverIdOrderByCreatedAtDesc(Long caregiverId);
+
+    // 보호자 ID로 쪽지 조회 (최신 3개)
+    List<Note> findTop3ByGuardianIdOrderByCreatedAtDesc(Long guardianId);
 }

--- a/src/main/java/com/iiie/server/repository/NoteRepository.java
+++ b/src/main/java/com/iiie/server/repository/NoteRepository.java
@@ -2,19 +2,20 @@ package com.iiie.server.repository;
 
 import com.iiie.server.domain.Note;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.List;
 import java.util.Optional;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
     // 간병인 ID로 쪽지 조회
-    Optional<List<Note>> findAllByCaregiverId(Long caregiverId);
+    List<Note> findAllByCaregiverId(Long caregiverId);
 
     // 보호자 ID로 쪽지 조회
-    Optional<List<Note>> findAllByGuardianId(Long guardianId);
+    List<Note> findAllByGuardianId(Long guardianId);
 
     // 간병인 ID로 쪽지 조회 (최신 3개)
-    Optional<List<Note>> findTop3ByCaregiverIdOrderByCreatedAtDesc(Long caregiverId);
+    List<Note> findTop3ByCaregiverIdOrderByCreatedAtDesc(Long caregiverId);
 
     // 보호자 ID로 쪽지 조회 (최신 3개)
-    Optional<List<Note>> findTop3ByGuardianIdOrderByCreatedAtDesc(Long guardianId);
+    List<Note> findTop3ByGuardianIdOrderByCreatedAtDesc(Long guardianId);
 }

--- a/src/main/java/com/iiie/server/repository/NoteRepository.java
+++ b/src/main/java/com/iiie/server/repository/NoteRepository.java
@@ -3,17 +3,18 @@ package com.iiie.server.repository;
 import com.iiie.server.domain.Note;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import java.util.Optional;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
     // 간병인 ID로 쪽지 조회
-    List<Note> findAllByCaregiverId(Long caregiverId);
+    Optional<List<Note>> findAllByCaregiverId(Long caregiverId);
 
     // 보호자 ID로 쪽지 조회
-    List<Note> findAllByGuardianId(Long guardianId);
+    Optional<List<Note>> findAllByGuardianId(Long guardianId);
 
     // 간병인 ID로 쪽지 조회 (최신 3개)
-    List<Note> findTop3ByCaregiverIdOrderByCreatedAtDesc(Long caregiverId);
+    Optional<List<Note>> findTop3ByCaregiverIdOrderByCreatedAtDesc(Long caregiverId);
 
     // 보호자 ID로 쪽지 조회 (최신 3개)
-    List<Note> findTop3ByGuardianIdOrderByCreatedAtDesc(Long guardianId);
+    Optional<List<Note>> findTop3ByGuardianIdOrderByCreatedAtDesc(Long guardianId);
 }

--- a/src/main/java/com/iiie/server/service/NoteService.java
+++ b/src/main/java/com/iiie/server/service/NoteService.java
@@ -33,14 +33,12 @@ public class NoteService {
         List<Note> notes;
 
         // 간병인 ID로 필터링
-        if (inquiryRequest.getCareGiverId() != null) {
-            notes = noteRepository.findAllByCaregiverId(inquiryRequest.getCareGiverId())
-                    .orElseThrow(() -> new NotFoundException("note", inquiryRequest.getCareGiverId(), "해당 간병인과 관련된 쪽지가 존재하지 않습니다."));
+        if (inquiryRequest.getCaregiverId() != null) {
+            notes = noteRepository.findAllByCaregiverId(inquiryRequest.getCaregiverId());
         }
         // 보호자 ID로 필터링
         else if (inquiryRequest.getGuardianId() != null) {
-            notes = noteRepository.findAllByGuardianId(inquiryRequest.getGuardianId())
-                    .orElseThrow(() -> new NotFoundException("note", inquiryRequest.getGuardianId(), "해당 보호자와 관련된 쪽지가 존재하지 않습니다."));
+            notes = noteRepository.findAllByGuardianId(inquiryRequest.getGuardianId());
         } else {
             throw new IllegalArgumentException("간병인 ID 또는 보호자 ID 중 하나는 반드시 제공되어야 합니다.");
         }
@@ -56,14 +54,12 @@ public class NoteService {
         List<Note> notes;
 
         // 간병인 ID로 조회
-        if (inquiryRequest.getCareGiverId() != null) {
-            notes = noteRepository.findTop3ByCaregiverIdOrderByCreatedAtDesc(inquiryRequest.getCareGiverId())
-                    .orElseThrow(() -> new NotFoundException("note", inquiryRequest.getCareGiverId(), "해당 간병인과 관련된 쪽지가 존재하지 않습니다."));
+        if (inquiryRequest.getCaregiverId() != null) {
+            notes = noteRepository.findTop3ByCaregiverIdOrderByCreatedAtDesc(inquiryRequest.getCaregiverId());
         }
         // 보호자 ID로 조회
         else if (inquiryRequest.getGuardianId() != null) {
-            notes = noteRepository.findTop3ByGuardianIdOrderByCreatedAtDesc(inquiryRequest.getGuardianId())
-                    .orElseThrow(() -> new NotFoundException("note", inquiryRequest.getGuardianId(), "해당 보호자와 관련된 쪽지가 존재하지 않습니다."));
+            notes = noteRepository.findTop3ByGuardianIdOrderByCreatedAtDesc(inquiryRequest.getGuardianId());
         } else {
             throw new IllegalArgumentException("간병인 ID 또는 보호자 ID 중 하나는 반드시 제공되어야 합니다.");
         }
@@ -80,9 +76,9 @@ public class NoteService {
         String createdByType = null;
 
         // 간병인이 작성한 경우
-        if (addRequest.getCareGiverId() != null) {
-            caregiver = caregiverRepository.findById(addRequest.getCareGiverId())
-                    .orElseThrow(() -> new NotFoundException("caregiver", addRequest.getCareGiverId(), "존재하지 않는 간병인입니다."));
+        if (addRequest.getCaregiverId() != null) {
+            caregiver = caregiverRepository.findById(addRequest.getCaregiverId())
+                    .orElseThrow(() -> new NotFoundException("caregiver", addRequest.getCaregiverId(), "존재하지 않는 간병인입니다."));
             guardian = caregiver.getGuardian();
             if (guardian == null) {
                 throw new IllegalStateException("매칭된 보호자를 찾을 수 없습니다.");

--- a/src/main/java/com/iiie/server/service/NoteService.java
+++ b/src/main/java/com/iiie/server/service/NoteService.java
@@ -50,8 +50,20 @@ public class NoteService {
     }
 
     @Transactional(readOnly = true)
-    public List<NoteDTO.NoteResponse> getLatestNotes() {
-        List<Note> notes = noteRepository.findTop3ByOrderByIdDesc();
+    public List<NoteDTO.NoteResponse> getLatestNotes(NoteDTO.InquiryRequest inquiryRequest) {
+        List<Note> notes;
+
+        // 간병인 ID로 조회
+        if (inquiryRequest.getCareGiverId() != null) {
+            notes = noteRepository.findTop3ByCaregiverIdOrderByCreatedAtDesc(inquiryRequest.getCareGiverId());
+        }
+        // 보호자 ID로 조회
+        else if (inquiryRequest.getGuardianId() != null) {
+            notes = noteRepository.findTop3ByGuardianIdOrderByCreatedAtDesc(inquiryRequest.getGuardianId());
+        } else {
+            throw new IllegalArgumentException("간병인 ID 또는 보호자 ID 중 하나는 반드시 제공되어야 합니다.");
+        }
+
         return notes.stream()
                 .map(this::convertToNoteResponse)
                 .collect(Collectors.toList());

--- a/src/main/java/com/iiie/server/service/NoteService.java
+++ b/src/main/java/com/iiie/server/service/NoteService.java
@@ -34,11 +34,13 @@ public class NoteService {
 
         // 간병인 ID로 필터링
         if (inquiryRequest.getCareGiverId() != null) {
-            notes = noteRepository.findAllByCaregiverId(inquiryRequest.getCareGiverId());
+            notes = noteRepository.findAllByCaregiverId(inquiryRequest.getCareGiverId())
+                    .orElseThrow(() -> new NotFoundException("note", inquiryRequest.getCareGiverId(), "해당 간병인과 관련된 쪽지가 존재하지 않습니다."));
         }
         // 보호자 ID로 필터링
         else if (inquiryRequest.getGuardianId() != null) {
-            notes = noteRepository.findAllByGuardianId(inquiryRequest.getGuardianId());
+            notes = noteRepository.findAllByGuardianId(inquiryRequest.getGuardianId())
+                    .orElseThrow(() -> new NotFoundException("note", inquiryRequest.getGuardianId(), "해당 보호자와 관련된 쪽지가 존재하지 않습니다."));
         } else {
             throw new IllegalArgumentException("간병인 ID 또는 보호자 ID 중 하나는 반드시 제공되어야 합니다.");
         }
@@ -55,11 +57,13 @@ public class NoteService {
 
         // 간병인 ID로 조회
         if (inquiryRequest.getCareGiverId() != null) {
-            notes = noteRepository.findTop3ByCaregiverIdOrderByCreatedAtDesc(inquiryRequest.getCareGiverId());
+            notes = noteRepository.findTop3ByCaregiverIdOrderByCreatedAtDesc(inquiryRequest.getCareGiverId())
+                    .orElseThrow(() -> new NotFoundException("note", inquiryRequest.getCareGiverId(), "해당 간병인과 관련된 쪽지가 존재하지 않습니다."));
         }
         // 보호자 ID로 조회
         else if (inquiryRequest.getGuardianId() != null) {
-            notes = noteRepository.findTop3ByGuardianIdOrderByCreatedAtDesc(inquiryRequest.getGuardianId());
+            notes = noteRepository.findTop3ByGuardianIdOrderByCreatedAtDesc(inquiryRequest.getGuardianId())
+                    .orElseThrow(() -> new NotFoundException("note", inquiryRequest.getGuardianId(), "해당 보호자와 관련된 쪽지가 존재하지 않습니다."));
         } else {
             throw new IllegalArgumentException("간병인 ID 또는 보호자 ID 중 하나는 반드시 제공되어야 합니다.");
         }


### PR DESCRIPTION
1. 간병인 또는 보호자 id를 통해 최근에 작성된 쪽지 3개 조회
2. note_id 이름 변경 및 노트 생성 일자를 년-월-일-시-분-초 모두 포함하도록 수정